### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,6 @@
 name: Go
+permissions:
+  contents: read
 on:
   create:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/bengarrett/bbs/security/code-scanning/2](https://github.com/bengarrett/bbs/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will explicitly limit the `GITHUB_TOKEN` permissions to the least privileges required for the workflow to function. Since the workflow involves checking out code, setting up Go, building, and testing, the `contents: read` permission is sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
